### PR TITLE
Add offline TypeScript highlighting and polish code styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Design Patterns Guide</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="app">
+    <aside class="sidebar">
+      <header class="sidebar__header">
+        <img src="robot-logo.svg" alt="Friendly robot" class="sidebar__logo" />
+        <h1>Design Patterns</h1>
+        <p class="sidebar__tagline">TypeScript-focused explanations</p>
+      </header>
+      <nav class="sidebar__nav" id="pattern-nav"></nav>
+    </aside>
+    <main class="content">
+      <header class="content__header">
+        <p class="content__breadcrumbs" id="pattern-category"></p>
+        <h2 class="content__title" id="pattern-title"></h2>
+      </header>
+      <section class="card" id="pattern-summary"></section>
+      <section class="card" id="pattern-benefits"></section>
+      <section class="card" id="pattern-examples"></section>
+    </main>
+  </div>
+  <script src="script.js" type="module"></script>
+</body>
+</html>

--- a/robot-logo.svg
+++ b/robot-logo.svg
@@ -1,0 +1,14 @@
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="14" y="26" width="68" height="52" rx="14" fill="#1F1F2E" stroke="#FF4D94" stroke-width="3"/>
+  <rect x="32" y="12" width="32" height="16" rx="6" fill="#292942" stroke="#FF4D94" stroke-width="3"/>
+  <rect x="24" y="36" width="48" height="32" rx="10" fill="#2B2B44"/>
+  <circle cx="38" cy="52" r="8" fill="#101018" stroke="#FF4D94" stroke-width="3"/>
+  <circle cx="58" cy="52" r="8" fill="#101018" stroke="#FF4D94" stroke-width="3"/>
+  <circle cx="38" cy="52" r="3" fill="#FFB5D2"/>
+  <circle cx="58" cy="52" r="3" fill="#FFB5D2"/>
+  <rect x="40" y="70" width="16" height="4" rx="2" fill="#FF4D94" opacity="0.7"/>
+  <path d="M20 46V34" stroke="#FF4D94" stroke-width="3" stroke-linecap="round"/>
+  <path d="M76 46V34" stroke="#FF4D94" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="48" cy="8" r="4" fill="#FF4D94"/>
+  <path d="M48 12V18" stroke="#FF4D94" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,2322 @@
+const highlightPatterns = [
+  { regex: /(\/\*[\s\S]*?\*\/|\/\/.*)/gm, type: 'comment' },
+  { regex: /(["'`])(?:\\.|(?!\1)[^\\])*\1/gm, type: 'string' },
+  { regex: /\b\d+(?:\.\d+)?\b/g, type: 'number' },
+  {
+    regex:
+      /\b(async|await|break|case|catch|class|const|continue|default|delete|do|else|enum|export|extends|finally|for|from|function|if|implements|import|in|instanceof|interface|let|new|of|private|protected|public|return|static|switch|throw|try|type|typeof|var|while|with|yield)\b/g,
+    type: 'keyword',
+  },
+  {
+    regex: /\b(string|number|boolean|void|any|unknown|never|Record|Partial|Pick|Omit|Map|Set|Promise|Array)\b/g,
+    type: 'type',
+  },
+  { regex: /\b(true|false|null|undefined|this|super)\b/g, type: 'literal' },
+  { regex: /@[a-zA-Z_][\w]*/g, type: 'decorator' },
+  { regex: /\b[A-Z][A-Za-z0-9_]*\b/g, type: 'class' },
+];
+
+function highlightTypeScript(code) {
+  const segments = [{ text: code, type: 'plain' }];
+
+  const applyPattern = (pattern) => {
+    for (let i = 0; i < segments.length; i += 1) {
+      const segment = segments[i];
+      if (segment.type !== 'plain') continue;
+
+      const matches = [];
+      let match;
+      pattern.regex.lastIndex = 0;
+      while ((match = pattern.regex.exec(segment.text))) {
+        matches.push({ start: match.index, end: match.index + match[0].length, text: match[0] });
+      }
+
+      if (!matches.length) continue;
+
+      const replacement = [];
+      let cursor = 0;
+
+      matches.forEach(({ start, end, text }) => {
+        if (start > cursor) {
+          replacement.push({ text: segment.text.slice(cursor, start), type: 'plain' });
+        }
+        replacement.push({ text, type: pattern.type });
+        cursor = end;
+      });
+
+      if (cursor < segment.text.length) {
+        replacement.push({ text: segment.text.slice(cursor), type: 'plain' });
+      }
+
+      segments.splice(i, 1, ...replacement);
+      i += replacement.length - 1;
+    }
+  };
+
+  highlightPatterns.forEach((pattern) => applyPattern(pattern));
+
+  const escapeHtml = (value) =>
+    value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+  return segments
+    .map(({ text, type }) => {
+      const escaped = escapeHtml(text);
+      if (type === 'plain') {
+        return escaped;
+      }
+      return `<span class="token token-${type}">${escaped}</span>`;
+    })
+    .join('');
+}
+
+function highlightSnippets(root) {
+  root.querySelectorAll('code').forEach((block) => {
+    if (block.dataset.highlighted === 'true') {
+      return;
+    }
+
+    const source = block.textContent ?? '';
+    block.innerHTML = highlightTypeScript(source);
+    block.dataset.highlighted = 'true';
+  });
+}
+
+const patterns = [
+  {
+    id: 'abstract-factory',
+    name: 'Abstract Factory',
+    category: 'Creational',
+    description:
+      'Provide an interface for creating families of related objects without specifying their concrete classes. Useful when products should work well together and you need to swap entire families easily.',
+    whenToUse: [
+      'You have related product variants that must stay compatible.',
+      'You want to enforce consistency across product families.',
+    ],
+    benefits: [
+      'Separates client code from concrete implementations.',
+      'Supports swapping product families without code changes.',
+    ],
+    downsides: [
+      'Adds extra abstraction layers and more classes to maintain.',
+      'Changing the product family structure requires updating every factory.',
+    ],
+    examples: [
+      {
+        title: 'UI Theme Factory',
+        code: `interface Button {
+  render(): string;
+}
+
+interface Dialog {
+  open(): string;
+}
+
+interface WidgetFactory {
+  createButton(): Button;
+  createDialog(): Dialog;
+}
+
+class DarkButton implements Button {
+  render() {
+    return 'Rendering dark button';
+  }
+}
+
+class DarkDialog implements Dialog {
+  open() {
+    return 'Opening dark dialog';
+  }
+}
+
+class DarkFactory implements WidgetFactory {
+  createButton() {
+    return new DarkButton();
+  }
+  createDialog() {
+    return new DarkDialog();
+  }
+}
+
+function renderUI(factory: WidgetFactory) {
+  console.log(factory.createButton().render());
+  console.log(factory.createDialog().open());
+}
+
+renderUI(new DarkFactory());`,
+      },
+      {
+        title: 'Cloud Provider Factory',
+        code: `interface StorageBucket {
+  upload(file: string): void;
+}
+
+interface MessageQueue {
+  publish(message: string): void;
+}
+
+interface CloudToolkit {
+  createBucket(): StorageBucket;
+  createQueue(): MessageQueue;
+}
+
+class AwsBucket implements StorageBucket {
+  upload(file: string) {
+    console.log('Uploading to S3', file);
+  }
+}
+
+class AwsQueue implements MessageQueue {
+  publish(message: string) {
+    console.log('Publishing to SNS', message);
+  }
+}
+
+class AwsToolkit implements CloudToolkit {
+  createBucket() {
+    return new AwsBucket();
+  }
+  createQueue() {
+    return new AwsQueue();
+  }
+}
+
+function deploy(toolkit: CloudToolkit) {
+  toolkit.createBucket().upload('report.pdf');
+  toolkit.createQueue().publish('Job finished');
+}
+
+deploy(new AwsToolkit());`,
+      },
+    ],
+  },
+  {
+    id: 'builder',
+    name: 'Builder',
+    category: 'Creational',
+    description:
+      'Construct complex objects step by step, letting the same construction process create different representations.',
+    whenToUse: [
+      'An object needs many optional pieces or configuration steps.',
+      'You want to isolate construction code from the final product.',
+    ],
+    benefits: [
+      'Keeps construction logic separate and reusable.',
+      'Helps create immutable, well-validated objects.',
+    ],
+    downsides: [
+      'More verbose than calling constructors directly.',
+      'Requires duplicating builder classes for each product variant.',
+    ],
+    examples: [
+      {
+        title: 'HTTP Request Builder',
+        code: `interface HttpRequest {
+  method: 'GET' | 'POST';
+  url: string;
+  headers: Record<string, string>;
+  body?: string;
+}
+
+class RequestBuilder {
+  private request: HttpRequest = {
+    method: 'GET',
+    url: '',
+    headers: {},
+  };
+
+  setMethod(method: 'GET' | 'POST') {
+    this.request.method = method;
+    return this;
+  }
+
+  setUrl(url: string) {
+    this.request.url = url;
+    return this;
+  }
+
+  addHeader(key: string, value: string) {
+    this.request.headers[key] = value;
+    return this;
+  }
+
+  setBody(body: string) {
+    this.request.body = body;
+    return this;
+  }
+
+  build() {
+    return Object.freeze({ ...this.request });
+  }
+}
+
+const request = new RequestBuilder()
+  .setMethod('POST')
+  .setUrl('/login')
+  .addHeader('Content-Type', 'application/json')
+  .setBody(JSON.stringify({ email: 'hi@example.com' }))
+  .build();`,
+      },
+      {
+        title: 'Game Character Builder',
+        code: `type Character = {
+  name: string;
+  weapon?: string;
+  skills: string[];
+};
+
+class CharacterBuilder {
+  private character: Character = { name: 'Hero', skills: [] };
+
+  named(name: string) {
+    this.character.name = name;
+    return this;
+  }
+
+  withWeapon(weapon: string) {
+    this.character.weapon = weapon;
+    return this;
+  }
+
+  addSkill(skill: string) {
+    this.character.skills.push(skill);
+    return this;
+  }
+
+  build(): Character {
+    return { ...this.character, skills: [...this.character.skills] };
+  }
+}
+
+const rogue = new CharacterBuilder()
+  .named('Shade')
+  .withWeapon('Daggers')
+  .addSkill('Stealth')
+  .addSkill('Poison Craft')
+  .build();`,
+      },
+    ],
+  },
+  {
+    id: 'factory-method',
+    name: 'Factory Method',
+    category: 'Creational',
+    description:
+      'Define an interface for creating an object, but let subclasses decide which class to instantiate.',
+    whenToUse: [
+      'A class cannot anticipate the type of objects it must create.',
+      'You want to encapsulate object creation for easier extension.',
+    ],
+    benefits: [
+      'Promotes loose coupling between creator and products.',
+      'Simplifies adding new product types by overriding the factory method.',
+    ],
+    downsides: [
+      'Adds subclassing just for object creation.',
+      'May produce many small classes for each product variant.',
+    ],
+    examples: [
+      {
+        title: 'Logger Factory',
+        code: `abstract class Logger {
+  abstract log(message: string): void;
+}
+
+class ConsoleLogger extends Logger {
+  log(message: string) {
+    console.log('[console]', message);
+  }
+}
+
+class FileLogger extends Logger {
+  log(message: string) {
+    console.log('[file]', message);
+  }
+}
+
+abstract class LoggerCreator {
+  abstract createLogger(): Logger;
+
+  report(message: string) {
+    const logger = this.createLogger();
+    logger.log(message);
+  }
+}
+
+class ConsoleLoggerCreator extends LoggerCreator {
+  createLogger() {
+    return new ConsoleLogger();
+  }
+}
+
+new ConsoleLoggerCreator().report('Server started');`,
+      },
+      {
+        title: 'Notification Factory',
+        code: `abstract class Notifier {
+  abstract send(message: string): void;
+}
+
+class SmsNotifier extends Notifier {
+  send(message: string) {
+    console.log('SMS:', message);
+  }
+}
+
+class EmailNotifier extends Notifier {
+  send(message: string) {
+    console.log('Email:', message);
+  }
+}
+
+abstract class NotifierCreator {
+  abstract createNotifier(): Notifier;
+
+  notifyUser(message: string) {
+    this.createNotifier().send(message);
+  }
+}
+
+class SmsNotifierCreator extends NotifierCreator {
+  createNotifier() {
+    return new SmsNotifier();
+  }
+}
+
+new SmsNotifierCreator().notifyUser('2FA code sent');`,
+      },
+    ],
+  },
+  {
+    id: 'prototype',
+    name: 'Prototype',
+    category: 'Creational',
+    description:
+      'Clone existing objects without making code dependent on their concrete classes. Good for heavy initialization or when creating objects is expensive.',
+    whenToUse: [
+      'Creating objects is costly and they share common setup.',
+      'You need to avoid subclass explosion for minor variations.',
+    ],
+    benefits: [
+      'Reduces duplication by reusing preconfigured instances.',
+      'Avoids coupling to concrete classes when cloning.',
+    ],
+    downsides: [
+      'Cloning complex structures can be tricky to implement correctly.',
+      'Deep copy requirements make maintenance harder.',
+    ],
+    examples: [
+      {
+        title: 'Document Prototype',
+        code: `interface Prototype<T> {
+  clone(): T;
+}
+
+class DocumentTemplate implements Prototype<DocumentTemplate> {
+  constructor(
+    public title: string,
+    public sections: string[]
+  ) {}
+
+  clone() {
+    return new DocumentTemplate(this.title, [...this.sections]);
+  }
+}
+
+const invoice = new DocumentTemplate('Invoice', ['Summary', 'Items']);
+const copy = invoice.clone();
+copy.sections.push('Notes');`,
+      },
+      {
+        title: 'Enemy Prototype',
+        code: `type EnemyStats = {
+  health: number;
+  attack: number;
+};
+
+class Enemy implements Prototype<Enemy> {
+  constructor(public type: string, public stats: EnemyStats) {}
+
+  clone() {
+    return new Enemy(this.type, { ...this.stats });
+  }
+}
+
+const baseOrc = new Enemy('Orc', { health: 100, attack: 15 });
+const eliteOrc = baseOrc.clone();
+eliteOrc.stats.attack += 10;`,
+      },
+    ],
+  },
+  {
+    id: 'singleton',
+    name: 'Singleton',
+    category: 'Creational',
+    description:
+      'Ensure a class has only one instance and provide a global access point to it.',
+    whenToUse: [
+      'You need a single shared resource such as configuration or cache.',
+      'You want lazy initialization of a heavy dependency.',
+    ],
+    benefits: [
+      'Controlled access to a single instance.',
+      'Can provide lazy initialization and lifecycle management.',
+    ],
+    downsides: [
+      'Hidden dependencies make testing harder.',
+      'Can become a bottleneck if overused.',
+    ],
+    examples: [
+      {
+        title: 'AppConfig Singleton',
+        code: `class AppConfig {
+  private static instance: AppConfig | undefined;
+
+  private constructor(public readonly apiUrl: string) {}
+
+  static getInstance() {
+    if (!this.instance) {
+      this.instance = new AppConfig('https://api.example.com');
+    }
+    return this.instance;
+  }
+}
+
+const config = AppConfig.getInstance();`,
+      },
+      {
+        title: 'Lazy Database Connection',
+        code: `class Database {
+  private static connection: Database | null = null;
+
+  private constructor(private connectionString: string) {}
+
+  static connect() {
+    if (!Database.connection) {
+      Database.connection = new Database('postgres://localhost');
+    }
+    return Database.connection;
+  }
+}
+
+const db = Database.connect();`,
+      },
+    ],
+  },
+  {
+    id: 'adapter',
+    name: 'Adapter',
+    category: 'Structural',
+    description:
+      'Convert the interface of a class into another interface clients expect. Lets incompatible classes work together.',
+    whenToUse: [
+      'Integrating third-party code with a different interface.',
+      'Reusing existing classes without modifying them.',
+    ],
+    benefits: [
+      'Allows reuse of existing functionality.',
+      'Supports incremental migration to new interfaces.',
+    ],
+    downsides: [
+      'Adds an extra layer that can hide inefficient code.',
+      'Multiple adapters can become hard to track.',
+    ],
+    examples: [
+      {
+        title: 'Payment Adapter',
+        code: `interface PaymentProcessor {
+  pay(total: number): void;
+}
+
+class Stripe {
+  charge(amount: number) {
+    console.log('Charging', amount);
+  }
+}
+
+class StripeAdapter implements PaymentProcessor {
+  constructor(private stripe: Stripe) {}
+
+  pay(total: number) {
+    this.stripe.charge(total);
+  }
+}
+
+function checkout(processor: PaymentProcessor) {
+  processor.pay(42);
+}
+
+checkout(new StripeAdapter(new Stripe()));`,
+      },
+      {
+        title: 'Legacy Logger Adapter',
+        code: `interface Logger {
+  info(message: string): void;
+}
+
+class LegacyLogger {
+  write(message: string) {
+    console.log('[legacy]', message);
+  }
+}
+
+class LoggerAdapter implements Logger {
+  constructor(private legacy: LegacyLogger) {}
+
+  info(message: string) {
+    this.legacy.write(message);
+  }
+}
+
+const logger = new LoggerAdapter(new LegacyLogger());
+logger.info('Migrated to adapter');`,
+      },
+    ],
+  },
+  {
+    id: 'bridge',
+    name: 'Bridge',
+    category: 'Structural',
+    description:
+      'Decouple an abstraction from its implementation so the two can vary independently.',
+    whenToUse: [
+      'You have classes that can be combined with multiple implementations.',
+      'Inheritance would lead to a Cartesian explosion of subclasses.',
+    ],
+    benefits: [
+      'Simplifies combining abstractions and implementations.',
+      'Improves testability by mocking either side independently.',
+    ],
+    downsides: [
+      'Requires planning two class hierarchies.',
+      'Can be overkill for simple use cases.',
+    ],
+    examples: [
+      {
+        title: 'Remote & Device Bridge',
+        code: `interface Device {
+  togglePower(): void;
+  setChannel(channel: number): void;
+}
+
+class Tv implements Device {
+  togglePower() {
+    console.log('TV power');
+  }
+  setChannel(channel: number) {
+    console.log('TV channel', channel);
+  }
+}
+
+class RemoteControl {
+  constructor(protected device: Device) {}
+
+  toggle() {
+    this.device.togglePower();
+  }
+}
+
+class AdvancedRemoteControl extends RemoteControl {
+  setChannel(channel: number) {
+    this.device.setChannel(channel);
+  }
+}
+
+const remote = new AdvancedRemoteControl(new Tv());
+remote.toggle();
+remote.setChannel(7);`,
+      },
+      {
+        title: 'Report & Exporter Bridge',
+        code: `interface Exporter {
+  export(data: object): string;
+}
+
+class JsonExporter implements Exporter {
+  export(data: object) {
+    return JSON.stringify(data);
+  }
+}
+
+abstract class Report {
+  constructor(protected exporter: Exporter) {}
+  abstract build(): object;
+
+  print() {
+    console.log(this.exporter.export(this.build()));
+  }
+}
+
+class SalesReport extends Report {
+  build() {
+    return { total: 1000, region: 'EU' };
+  }
+}
+
+new SalesReport(new JsonExporter()).print();`,
+      },
+    ],
+  },
+  {
+    id: 'composite',
+    name: 'Composite',
+    category: 'Structural',
+    description:
+      'Compose objects into tree structures to represent part-whole hierarchies and work with all nodes uniformly.',
+    whenToUse: [
+      'You need to treat individual and composite objects the same way.',
+      'Tree-like structures are core to the domain (UI, file systems).',
+    ],
+    benefits: [
+      'Simplifies client code by handling leaf and composite uniformly.',
+      'Makes it easy to add new element types.',
+    ],
+    downsides: [
+      'Can make validation and constraints harder to enforce.',
+      'Difficult to restrict certain components in the tree.',
+    ],
+    examples: [
+      {
+        title: 'File System Composite',
+        code: `interface FileSystemNode {
+  getSize(): number;
+}
+
+class FileLeaf implements FileSystemNode {
+  constructor(private size: number) {}
+  getSize() {
+    return this.size;
+  }
+}
+
+class Folder implements FileSystemNode {
+  private children: FileSystemNode[] = [];
+
+  add(child: FileSystemNode) {
+    this.children.push(child);
+  }
+
+  getSize() {
+    return this.children.reduce((total, child) => total + child.getSize(), 0);
+  }
+}
+
+const root = new Folder();
+root.add(new FileLeaf(10));
+root.add(new FileLeaf(20));
+console.log(root.getSize());`,
+      },
+      {
+        title: 'UI Component Tree',
+        code: `interface Component {
+  draw(): void;
+}
+
+class Button implements Component {
+  draw() {
+    console.log('Drawing button');
+  }
+}
+
+class Panel implements Component {
+  private children: Component[] = [];
+
+  add(component: Component) {
+    this.children.push(component);
+  }
+
+  draw() {
+    this.children.forEach((child) => child.draw());
+  }
+}
+
+const panel = new Panel();
+panel.add(new Button());
+panel.draw();`,
+      },
+    ],
+  },
+  {
+    id: 'decorator',
+    name: 'Decorator',
+    category: 'Structural',
+    description:
+      'Attach additional responsibilities to an object dynamically. Provides a flexible alternative to subclassing for extending functionality.',
+    whenToUse: [
+      'You need to add behavior without modifying original classes.',
+      'Different combinations of features should be possible at runtime.',
+    ],
+    benefits: [
+      'Stacks features without subclass explosion.',
+      'Keeps core classes lightweight.',
+    ],
+    downsides: [
+      'Many small objects can make debugging harder.',
+      'Order of decorators may affect behavior.',
+    ],
+    examples: [
+      {
+        title: 'Coffee Decorators',
+        code: `interface Coffee {
+  cost(): number;
+}
+
+class Espresso implements Coffee {
+  cost() {
+    return 2;
+  }
+}
+
+class MilkDecorator implements Coffee {
+  constructor(private base: Coffee) {}
+
+  cost() {
+    return this.base.cost() + 0.5;
+  }
+}
+
+const latte = new MilkDecorator(new Espresso());
+console.log(latte.cost());`,
+      },
+      {
+        title: 'HTTP Client with Decorators',
+        code: `interface HttpClient {
+  get(url: string): Promise<string>;
+}
+
+class FetchClient implements HttpClient {
+  async get(url: string) {
+    const res = await fetch(url);
+    return res.text();
+  }
+}
+
+class LoggingClient implements HttpClient {
+  constructor(private inner: HttpClient) {}
+
+  async get(url: string) {
+    console.log('Requesting', url);
+    return this.inner.get(url);
+  }
+}
+
+const client = new LoggingClient(new FetchClient());`,
+      },
+    ],
+  },
+  {
+    id: 'facade',
+    name: 'Facade',
+    category: 'Structural',
+    description:
+      'Provide a unified interface to a set of interfaces in a subsystem, making it easier to use.',
+    whenToUse: [
+      'Subsystems are complex or difficult to understand.',
+      'You want a single entry point to common workflows.',
+    ],
+    benefits: [
+      'Simplifies usage of complex libraries.',
+      'Promotes loose coupling between clients and subsystems.',
+    ],
+    downsides: [
+      'Can become a god object if it grows too much.',
+      'Hiding details might limit advanced usage.',
+    ],
+    examples: [
+      {
+        title: 'Video Conversion Facade',
+        code: `class FileLoader {
+  load(path: string) {
+    console.log('Loading file', path);
+  }
+}
+
+class CodecConverter {
+  convert(format: string) {
+    console.log('Converting to', format);
+  }
+}
+
+class VideoConverterFacade {
+  private loader = new FileLoader();
+  private converter = new CodecConverter();
+
+  convert(path: string, format: string) {
+    this.loader.load(path);
+    this.converter.convert(format);
+    console.log('Done!');
+  }
+}
+
+new VideoConverterFacade().convert('intro.mov', 'mp4');`,
+      },
+      {
+        title: 'Analytics Facade',
+        code: `class EventTracker {
+  track(event: string) {
+    console.log('Tracking', event);
+  }
+}
+
+class UserStorage {
+  save(userId: string) {
+    console.log('Saving user', userId);
+  }
+}
+
+class AnalyticsFacade {
+  private tracker = new EventTracker();
+  private storage = new UserStorage();
+
+  identify(userId: string) {
+    this.storage.save(userId);
+    this.tracker.track('identify');
+  }
+}
+
+const analytics = new AnalyticsFacade();
+analytics.identify('123');`,
+      },
+    ],
+  },
+  {
+    id: 'flyweight',
+    name: 'Flyweight',
+    category: 'Structural',
+    description:
+      'Share common state between multiple objects to support large numbers efficiently.',
+    whenToUse: [
+      'You have many similar objects that use a lot of memory.',
+      'Most object data can be shared rather than duplicated.',
+    ],
+    benefits: [
+      'Reduces memory footprint by reusing intrinsic state.',
+      'Can improve cache locality for repeated data.',
+    ],
+    downsides: [
+      'Requires splitting state into shared vs. unique parts.',
+      'Introduces complexity in managing shared objects.',
+    ],
+    examples: [
+      {
+        title: 'Tree Type Flyweight',
+        code: `class TreeType {
+  constructor(public texture: string) {}
+}
+
+class TreeFactory {
+  private types = new Map<string, TreeType>();
+
+  getType(texture: string) {
+    if (!this.types.has(texture)) {
+      this.types.set(texture, new TreeType(texture));
+    }
+    return this.types.get(texture)!;
+  }
+}
+
+const factory = new TreeFactory();
+const oak1 = factory.getType('oak.png');
+const oak2 = factory.getType('oak.png');
+console.log(oak1 === oak2);`,
+      },
+      {
+        title: 'Text Character Flyweight',
+        code: `type GlyphState = {
+  symbol: string;
+};
+
+type Position = {
+  x: number;
+  y: number;
+  color: string;
+};
+
+class GlyphFactory {
+  private glyphs = new Map<string, GlyphState>();
+
+  get(symbol: string) {
+    if (!this.glyphs.has(symbol)) {
+      this.glyphs.set(symbol, { symbol });
+    }
+    return this.glyphs.get(symbol)!;
+  }
+}
+
+const glyphFactory = new GlyphFactory();
+const sharedA = glyphFactory.get('A');
+const secondA = glyphFactory.get('A');
+console.log(sharedA === secondA);`,
+      },
+    ],
+  },
+  {
+    id: 'proxy',
+    name: 'Proxy',
+    category: 'Structural',
+    description:
+      'Provide a surrogate or placeholder for another object to control access to it.',
+    whenToUse: [
+      'You need lazy loading, caching, or access control.',
+      'You want to add cross-cutting concerns around a class.',
+    ],
+    benefits: [
+      'Adds behavior without changing the real subject.',
+      'Can defer heavy work until necessary.',
+    ],
+    downsides: [
+      'Introduces extra indirection and latency.',
+      'Increases code complexity and maintenance.',
+    ],
+    examples: [
+      {
+        title: 'Image Proxy',
+        code: `interface Image {
+  display(): void;
+}
+
+class RealImage implements Image {
+  constructor(private path: string) {}
+
+  display() {
+    console.log('Showing image', this.path);
+  }
+}
+
+class ImageProxy implements Image {
+  private real?: RealImage;
+
+  constructor(private path: string) {}
+
+  display() {
+    if (!this.real) {
+      this.real = new RealImage(this.path);
+    }
+    this.real.display();
+  }
+}
+
+const image = new ImageProxy('logo.png');
+image.display();`,
+      },
+      {
+        title: 'Permissions Proxy',
+        code: `interface Document {
+  read(): string;
+}
+
+class ProtectedDocument implements Document {
+  constructor(private content: string) {}
+
+  read() {
+    return this.content;
+  }
+}
+
+class DocumentProxy implements Document {
+  constructor(private doc: Document, private canRead: boolean) {}
+
+  read() {
+    if (!this.canRead) {
+      throw new Error('Access denied');
+    }
+    return this.doc.read();
+  }
+}
+
+const secureDoc = new DocumentProxy(new ProtectedDocument('secret'), true);
+console.log(secureDoc.read());`,
+      },
+    ],
+  },
+  {
+    id: 'chain-of-responsibility',
+    name: 'Chain of Responsibility',
+    category: 'Behavioral',
+    description:
+      'Pass requests along a chain of handlers until one of them handles it.',
+    whenToUse: [
+      'Multiple objects can handle a request, and you want the handler chosen at runtime.',
+      'You need to decouple senders and receivers.',
+    ],
+    benefits: [
+      'Promotes loose coupling between sender and handler.',
+      'Supports adding or reordering handlers without breaking code.',
+    ],
+    downsides: [
+      'Requests might go unhandled if not terminated properly.',
+      'Debugging across many handlers can be difficult.',
+    ],
+    examples: [
+      {
+        title: 'Support Ticket Escalation',
+        code: `abstract class SupportHandler {
+  private next?: SupportHandler;
+
+  setNext(handler: SupportHandler) {
+    this.next = handler;
+    return handler;
+  }
+
+  handle(level: 'low' | 'high') {
+    if (this.next) {
+      this.next.handle(level);
+    } else {
+      console.log('No handler available');
+    }
+  }
+}
+
+class AgentSupport extends SupportHandler {
+  handle(level: 'low' | 'high') {
+    if (level === 'low') {
+      console.log('Agent resolved ticket');
+    } else {
+      super.handle(level);
+    }
+  }
+}
+
+class ManagerSupport extends SupportHandler {
+  handle(level: 'low' | 'high') {
+    if (level === 'high') {
+      console.log('Manager resolved ticket');
+    } else {
+      super.handle(level);
+    }
+  }
+}
+
+const supportChain = new AgentSupport();
+supportChain.setNext(new ManagerSupport());
+supportChain.handle('high');`,
+      },
+      {
+        title: 'Middleware Chain',
+        code: `type Context = { user?: string };
+
+abstract class Middleware {
+  private next?: Middleware;
+
+  linkWith(next: Middleware) {
+    this.next = next;
+    return next;
+  }
+
+  handle(context: Context) {
+    if (this.next) {
+      this.next.handle(context);
+    }
+  }
+}
+
+class AuthMiddleware extends Middleware {
+  handle(context: Context) {
+    if (!context.user) {
+      throw new Error('No user');
+    }
+    console.log('User authenticated');
+    super.handle(context);
+  }
+}
+
+const pipeline = new AuthMiddleware();
+pipeline.handle({ user: 'sarah' });`,
+      },
+    ],
+  },
+  {
+    id: 'command',
+    name: 'Command',
+    category: 'Behavioral',
+    description:
+      'Encapsulate a request as an object, letting you parameterize clients, queue, and log requests.',
+    whenToUse: [
+      'You need to queue, undo, or log operations.',
+      'Commands should be executed at different times by different objects.',
+    ],
+    benefits: [
+      'Decouples sender from receiver.',
+      'Supports undo/redo via command history.',
+    ],
+    downsides: [
+      'Adds new classes for each command type.',
+      'Can complicate simple operations unnecessarily.',
+    ],
+    examples: [
+      {
+        title: 'Light Switch Command',
+        code: `interface Command {
+  execute(): void;
+}
+
+class Light {
+  on() {
+    console.log('Light on');
+  }
+  off() {
+    console.log('Light off');
+  }
+}
+
+class OnCommand implements Command {
+  constructor(private light: Light) {}
+  execute() {
+    this.light.on();
+  }
+}
+
+class Remote {
+  constructor(private command: Command) {}
+  press() {
+    this.command.execute();
+  }
+}
+
+new Remote(new OnCommand(new Light())).press();`,
+      },
+      {
+        title: 'Queueable Job Command',
+        code: `interface Job {
+  run(): Promise<void>;
+}
+
+class EmailJob implements Job {
+  async run() {
+    console.log('Sending email...');
+  }
+}
+
+class JobRunner {
+  private queue: Job[] = [];
+
+  add(job: Job) {
+    this.queue.push(job);
+  }
+
+  async process() {
+    for (const job of this.queue) {
+      await job.run();
+    }
+  }
+}
+
+const runner = new JobRunner();
+runner.add(new EmailJob());
+runner.process();`,
+      },
+    ],
+  },
+  {
+    id: 'interpreter',
+    name: 'Interpreter',
+    category: 'Behavioral',
+    description:
+      'Define a representation for a simple language and interpret its sentences.',
+    whenToUse: [
+      'You have a simple grammar to evaluate repeatedly.',
+      'You want to build DSL-like features with composable expressions.',
+    ],
+    benefits: [
+      'Each grammar rule gets its own class for clarity.',
+      'Composing expressions is straightforward.',
+    ],
+    downsides: [
+      'Complex grammars lead to many small classes.',
+      'Performance can suffer compared to optimized parsers.',
+    ],
+    examples: [
+      {
+        title: 'Math Expression Interpreter',
+        code: `interface Expression {
+  interpret(): number;
+}
+
+class NumberLiteral implements Expression {
+  constructor(private value: number) {}
+
+  interpret() {
+    return this.value;
+  }
+}
+
+class Add implements Expression {
+  constructor(private left: Expression, private right: Expression) {}
+
+  interpret() {
+    return this.left.interpret() + this.right.interpret();
+  }
+}
+
+const result = new Add(new NumberLiteral(2), new NumberLiteral(3)).interpret();`,
+      },
+      {
+        title: 'Boolean DSL',
+        code: `interface BooleanExpression {
+  interpret(context: Record<string, boolean>): boolean;
+}
+
+class Variable implements BooleanExpression {
+  constructor(private name: string) {}
+  interpret(context: Record<string, boolean>) {
+    return context[this.name];
+  }
+}
+
+class And implements BooleanExpression {
+  constructor(private left: BooleanExpression, private right: BooleanExpression) {}
+  interpret(context: Record<string, boolean>) {
+    return this.left.interpret(context) && this.right.interpret(context);
+  }
+}
+
+const expr = new And(new Variable('isAdmin'), new Variable('isActive'));
+expr.interpret({ isAdmin: true, isActive: false });`,
+      },
+    ],
+  },
+  {
+    id: 'iterator',
+    name: 'Iterator',
+    category: 'Behavioral',
+    description:
+      'Provide a way to access the elements of an aggregate object sequentially without exposing its underlying representation.',
+    whenToUse: [
+      'You need multiple traversal strategies for a collection.',
+      'Want to hide collection internals from consumers.',
+    ],
+    benefits: [
+      'Supports different traversals over the same collection.',
+      'Encapsulates iteration state.',
+    ],
+    downsides: [
+      'Extra classes for custom iterators.',
+      'Can be unnecessary when language already provides iteration tools.',
+    ],
+    examples: [
+      {
+        title: 'Custom Range Iterator',
+        code: `class Range implements Iterable<number> {
+  constructor(private start: number, private end: number) {}
+
+  [Symbol.iterator]() {
+    let current = this.start;
+    return {
+      next: () => ({
+        value: current,
+        done: current++ > this.end,
+      }),
+    };
+  }
+}
+
+for (const value of new Range(1, 3)) {
+  console.log(value);
+}`,
+      },
+      {
+        title: 'Playlist Iterator',
+        code: `class Playlist implements Iterable<string> {
+  constructor(private tracks: string[]) {}
+
+  [Symbol.iterator]() {
+    let index = 0;
+    return {
+      next: () => ({
+        value: this.tracks[index],
+        done: index++ >= this.tracks.length,
+      }),
+    };
+  }
+}
+
+for (const track of new Playlist(['Intro', 'Verse'])) {
+  console.log(track);
+}`,
+      },
+    ],
+  },
+  {
+    id: 'mediator',
+    name: 'Mediator',
+    category: 'Behavioral',
+    description:
+      'Define an object that encapsulates how a set of objects interact, promoting loose coupling.',
+    whenToUse: [
+      'Components communicate in complex ways.',
+      'You want to centralize communication logic.',
+    ],
+    benefits: [
+      'Reduces direct dependencies between components.',
+      'Encapsulates protocols in one place.',
+    ],
+    downsides: [
+      'Mediator can become monolithic if it grows unchecked.',
+      'Another layer to maintain and test.',
+    ],
+    examples: [
+      {
+        title: 'Chat Room Mediator',
+        code: `class ChatRoom {
+  private participants: Participant[] = [];
+
+  register(participant: Participant) {
+    this.participants.push(participant);
+  }
+
+  broadcast(from: string, message: string) {
+    this.participants.forEach((user) => {
+      if (user.name !== from) {
+        user.receive(message);
+      }
+    });
+  }
+}
+
+class Participant {
+  constructor(public name: string, private room: ChatRoom) {
+    this.room.register(this);
+  }
+
+  send(message: string) {
+    this.room.broadcast(this.name, message);
+  }
+
+  receive(message: string) {
+    console.log(this.name + ' received: ' + message);
+  }
+}
+
+const room = new ChatRoom();
+const alex = new Participant('Alex', room);
+alex.send('Hello');`,
+      },
+      {
+        title: 'UI Form Mediator',
+        code: `class FormMediator {
+  constructor(private fields: FormField[]) {
+    fields.forEach((field) => field.setMediator(this));
+  }
+
+  notify(sender: FormField, event: 'focus' | 'blur') {
+    if (event === 'focus') {
+      this.fields.forEach((field) => {
+        if (field !== sender) field.blur();
+      });
+    }
+  }
+}
+
+abstract class FormField {
+  protected mediator?: FormMediator;
+
+  setMediator(mediator: FormMediator) {
+    this.mediator = mediator;
+  }
+
+  focus() {
+    this.mediator?.notify(this, 'focus');
+  }
+
+  abstract blur(): void;
+}
+
+class TextField extends FormField {
+  blur() {
+    console.log('Field blurred');
+  }
+}
+
+const username = new TextField();
+const password = new TextField();
+new FormMediator([username, password]);
+username.focus();`,
+      },
+    ],
+  },
+  {
+    id: 'memento',
+    name: 'Memento',
+    category: 'Behavioral',
+    description:
+      'Capture and externalize an object’s internal state so it can be restored later without violating encapsulation.',
+    whenToUse: [
+      'You need undo/redo functionality.',
+      'Snapshots of object state should be stored safely.',
+    ],
+    benefits: [
+      'Encapsulates state snapshots cleanly.',
+      'Allows restoring state without exposing internals.',
+    ],
+    downsides: [
+      'Can consume a lot of memory for large states.',
+      'Requires care when dealing with mutable references.',
+    ],
+    examples: [
+      {
+        title: 'Text Editor History',
+        code: `class EditorMemento {
+  constructor(public readonly content: string) {}
+}
+
+class TextEditor {
+  private history: EditorMemento[] = [];
+
+  constructor(private content = '') {}
+
+  type(text: string) {
+    this.content += text;
+    this.save();
+  }
+
+  save() {
+    this.history.push(new EditorMemento(this.content));
+  }
+
+  undo() {
+    const memento = this.history.pop();
+    if (memento) {
+      this.content = memento.content;
+    }
+  }
+}
+
+const editor = new TextEditor();
+editor.type('Hello');
+editor.undo();`,
+      },
+      {
+        title: 'Game Save System',
+        code: `type GameState = {
+  level: number;
+  health: number;
+};
+
+class GameMemento {
+  constructor(public readonly state: GameState) {}
+}
+
+class Game {
+  private saves: GameMemento[] = [];
+
+  constructor(private state: GameState) {}
+
+  save() {
+    this.saves.push(new GameMemento({ ...this.state }));
+  }
+
+  restore() {
+    const memento = this.saves.pop();
+    if (memento) {
+      this.state = memento.state;
+    }
+  }
+}
+
+const game = new Game({ level: 1, health: 100 });
+game.save();
+game.restore();`,
+      },
+    ],
+  },
+  {
+    id: 'observer',
+    name: 'Observer',
+    category: 'Behavioral',
+    description:
+      'Define a one-to-many dependency between objects so when one object changes state, all its dependents are notified.',
+    whenToUse: [
+      'Multiple consumers need to react to state changes.',
+      'You want to decouple publishers from subscribers.',
+    ],
+    benefits: [
+      'Supports broadcast communication.',
+      'Observers can be added or removed at runtime.',
+    ],
+    downsides: [
+      'Notification order might be unpredictable.',
+      'Observers can miss updates if not managed carefully.',
+    ],
+    examples: [
+      {
+        title: 'Stock Price Observer',
+        code: `type Listener = (price: number) => void;
+
+class StockTicker {
+  private listeners: Listener[] = [];
+
+  subscribe(listener: Listener) {
+    this.listeners.push(listener);
+  }
+
+  update(price: number) {
+    this.listeners.forEach((listener) => listener(price));
+  }
+}
+
+const ticker = new StockTicker();
+ticker.subscribe((price) => console.log('Price:', price));
+ticker.update(120);
+`,
+      },
+      {
+        title: 'Weather Station Observer',
+        code: `interface WeatherObserver {
+  notify(temp: number): void;
+}
+
+class WeatherStation {
+  private observers = new Set<WeatherObserver>();
+
+  add(observer: WeatherObserver) {
+    this.observers.add(observer);
+  }
+
+  setTemperature(temp: number) {
+    this.observers.forEach((observer) => observer.notify(temp));
+  }
+}
+
+class Display implements WeatherObserver {
+  notify(temp: number) {
+    console.log('Now', temp);
+  }
+}
+
+const station = new WeatherStation();
+station.add(new Display());
+station.setTemperature(22);`,
+      },
+    ],
+  },
+  {
+    id: 'state',
+    name: 'State',
+    category: 'Behavioral',
+    description:
+      'Allow an object to alter its behavior when its internal state changes.',
+    whenToUse: [
+      'Object behavior depends on current state.',
+      'State transitions are frequent and complex.',
+    ],
+    benefits: [
+      'Localizes state-specific logic to dedicated classes.',
+      'Makes transitions explicit and testable.',
+    ],
+    downsides: [
+      'More classes and indirection.',
+      'State transitions may be scattered across state classes.',
+    ],
+    examples: [
+      {
+        title: 'Order Lifecycle States',
+        code: `interface OrderState {
+  next(order: Order): void;
+}
+
+class Order {
+  constructor(public state: OrderState) {}
+
+  advance() {
+    this.state.next(this);
+  }
+}
+
+class PendingState implements OrderState {
+  next(order: Order) {
+    order.state = new ShippedState();
+  }
+}
+
+class ShippedState implements OrderState {
+  next(order: Order) {
+    order.state = new DeliveredState();
+  }
+}
+
+class DeliveredState implements OrderState {
+  next() {
+    console.log('Order complete');
+  }
+}
+
+const order = new Order(new PendingState());
+order.advance();`,
+      },
+      {
+        title: 'Audio Player States',
+        code: `interface PlayerState {
+  play(player: AudioPlayer): void;
+}
+
+class AudioPlayer {
+  state: PlayerState = new StoppedState();
+
+  play() {
+    this.state.play(this);
+  }
+}
+
+class StoppedState implements PlayerState {
+  play(player: AudioPlayer) {
+    console.log('Playing');
+    player.state = new PlayingState();
+  }
+}
+
+class PlayingState implements PlayerState {
+  play(player: AudioPlayer) {
+    console.log('Already playing');
+  }
+}
+
+const player = new AudioPlayer();
+player.play();`,
+      },
+    ],
+  },
+  {
+    id: 'strategy',
+    name: 'Strategy',
+    category: 'Behavioral',
+    description:
+      'Define a family of algorithms, encapsulate each one, and make them interchangeable.',
+    whenToUse: [
+      'Multiple algorithms can solve the same problem.',
+      'You want to swap implementations at runtime.',
+    ],
+    benefits: [
+      'Isolates algorithm implementations.',
+      'Follows open/closed principle for new strategies.',
+    ],
+    downsides: [
+      'Clients must understand differences between strategies.',
+      'Requires creating additional objects.',
+    ],
+    examples: [
+      {
+        title: 'Shipping Cost Strategy',
+        code: `interface ShippingStrategy {
+  calculate(weight: number): number;
+}
+
+class GroundShipping implements ShippingStrategy {
+  calculate(weight: number) {
+    return weight * 1.2;
+  }
+}
+
+class AirShipping implements ShippingStrategy {
+  calculate(weight: number) {
+    return weight * 2.5;
+  }
+}
+
+class ShippingCostCalculator {
+  constructor(private strategy: ShippingStrategy) {}
+
+  total(weight: number) {
+    return this.strategy.calculate(weight);
+  }
+}
+
+new ShippingCostCalculator(new GroundShipping()).total(3);`,
+      },
+      {
+        title: 'Sorting Strategy',
+        code: `type SortStrategy = {
+  sort(items: number[]): number[];
+};
+
+class AscendingSort implements SortStrategy {
+  sort(items: number[]) {
+    return [...items].sort((a, b) => a - b);
+  }
+}
+
+class DescendingSort implements SortStrategy {
+  sort(items: number[]) {
+    return [...items].sort((a, b) => b - a);
+  }
+}
+
+const sorter = new AscendingSort();
+sorter.sort([3, 1, 2]);`,
+      },
+    ],
+  },
+  {
+    id: 'template-method',
+    name: 'Template Method',
+    category: 'Behavioral',
+    description:
+      'Define the skeleton of an algorithm in an operation, deferring some steps to subclasses.',
+    whenToUse: [
+      'Algorithms share structure but differ in details.',
+      'You want to enforce ordering of operations.',
+    ],
+    benefits: [
+      'Promotes reuse of high-level workflow logic.',
+      'Keeps variant steps customizable via subclassing.',
+    ],
+    downsides: [
+      'Inheritance-based, so it increases coupling.',
+      'Changes in template require touching all subclasses.',
+    ],
+    examples: [
+      {
+        title: 'Data Export Template',
+        code: `abstract class DataExporter {
+  export() {
+    const data = this.fetchData();
+    const transformed = this.transform(data);
+    this.save(transformed);
+  }
+
+  protected abstract fetchData(): string;
+  protected abstract transform(data: string): string;
+  protected save(data: string) {
+    console.log('Saving', data);
+  }
+}
+
+class JsonExporter extends DataExporter {
+  protected fetchData() {
+    return '{"name":"Pat"}';
+  }
+  protected transform(data: string) {
+    return data.toUpperCase();
+  }
+}
+
+new JsonExporter().export();`,
+      },
+      {
+        title: 'Build Pipeline Template',
+        code: `abstract class BuildPipeline {
+  run() {
+    this.install();
+    this.test();
+    this.deploy();
+  }
+
+  protected abstract install(): void;
+  protected abstract test(): void;
+  protected abstract deploy(): void;
+}
+
+class WebPipeline extends BuildPipeline {
+  protected install() {
+    console.log('npm install');
+  }
+  protected test() {
+    console.log('npm test');
+  }
+  protected deploy() {
+    console.log('Deploying web build');
+  }
+}
+
+new WebPipeline().run();`,
+      },
+    ],
+  },
+  {
+    id: 'visitor',
+    name: 'Visitor',
+    category: 'Behavioral',
+    description:
+      'Represent an operation to be performed on elements of an object structure without changing the classes of the elements.',
+    whenToUse: [
+      'You need to perform new operations on objects without modifying them.',
+      'The object structure rarely changes but new operations are added often.',
+    ],
+    benefits: [
+      'Adds new operations without touching element classes.',
+      'Collects related behavior in visitor implementations.',
+    ],
+    downsides: [
+      'Adding new element types requires updating all visitors.',
+      'Breaks encapsulation if visitors need access to internals.',
+    ],
+    examples: [
+      {
+        title: 'Tax Visitor',
+        code: `interface ProductVisitor {
+  visitBook(book: Book): number;
+  visitFood(food: Food): number;
+}
+
+interface Product {
+  accept(visitor: ProductVisitor): number;
+}
+
+class Book implements Product {
+  constructor(public price: number) {}
+  accept(visitor: ProductVisitor) {
+    return visitor.visitBook(this);
+  }
+}
+
+class Food implements Product {
+  constructor(public price: number) {}
+  accept(visitor: ProductVisitor) {
+    return visitor.visitFood(this);
+  }
+}
+
+class TaxCalculator implements ProductVisitor {
+  visitBook(book: Book) {
+    return book.price * 1.1;
+  }
+  visitFood(food: Food) {
+    return food.price * 1.05;
+  }
+}
+
+const cart: Product[] = [new Book(20), new Food(10)];
+const total = cart.reduce((sum, item) => sum + item.accept(new TaxCalculator()), 0);`,
+      },
+      {
+        title: 'AST Visitor',
+        code: `interface NodeVisitor {
+  visitLiteral(literal: Literal): void;
+  visitBinary(binary: BinaryExpression): void;
+}
+
+interface AstNode {
+  accept(visitor: NodeVisitor): void;
+}
+
+class Literal implements AstNode {
+  constructor(public value: number) {}
+  accept(visitor: NodeVisitor) {
+    visitor.visitLiteral(this);
+  }
+}
+
+class BinaryExpression implements AstNode {
+  constructor(public left: AstNode, public right: AstNode) {}
+  accept(visitor: NodeVisitor) {
+    visitor.visitBinary(this);
+  }
+}
+
+class PrintVisitor implements NodeVisitor {
+  visitLiteral(literal: Literal) {
+    console.log(literal.value);
+  }
+  visitBinary(binary: BinaryExpression) {
+    binary.left.accept(this);
+    binary.right.accept(this);
+  }
+}
+
+const ast = new BinaryExpression(new Literal(1), new Literal(2));
+ast.accept(new PrintVisitor());`,
+      },
+    ],
+  },
+  {
+    id: 'flux',
+    name: 'Flux',
+    category: 'Modern',
+    description:
+      'A unidirectional data flow architecture often used with React applications.',
+    whenToUse: [
+      'Your UI state becomes complex and needs predictable updates.',
+      'You want to separate state updates from view rendering.',
+    ],
+    benefits: [
+      'Predictable data flow with centralized state changes.',
+      'Simplifies debugging with action logs.',
+    ],
+    downsides: [
+      'Boilerplate for defining actions and dispatchers.',
+      'Single store can grow large without modularization.',
+    ],
+    examples: [
+      {
+        title: 'Counter Flux Loop',
+        code: `type Action = { type: 'increment' } | { type: 'reset' };
+
+type State = { count: number };
+
+class Dispatcher {
+  private listeners: ((action: Action) => void)[] = [];
+  register(listener: (action: Action) => void) {
+    this.listeners.push(listener);
+  }
+  dispatch(action: Action) {
+    this.listeners.forEach((listener) => listener(action));
+  }
+}
+
+class Store {
+  private state: State = { count: 0 };
+  constructor(private dispatcher: Dispatcher) {
+    dispatcher.register((action) => this.reduce(action));
+  }
+  private reduce(action: Action) {
+    if (action.type === 'increment') {
+      this.state.count++;
+    } else {
+      this.state.count = 0;
+    }
+    console.log('State:', this.state);
+  }
+}
+
+const dispatcher = new Dispatcher();
+new Store(dispatcher);
+dispatcher.dispatch({ type: 'increment' });`,
+      },
+      {
+        title: 'Todo Flux Example',
+        code: `type TodoAction =
+  | { type: 'add'; text: string }
+  | { type: 'toggle'; id: number };
+
+type Todo = { id: number; text: string; completed: boolean };
+
+type Listener = () => void;
+
+class TodoStore {
+  private todos: Todo[] = [];
+  private listeners: Listener[] = [];
+
+  constructor(dispatcher: Dispatcher) {
+    dispatcher.register((action) => this.reduce(action));
+  }
+
+  private reduce(action: TodoAction) {
+    if (action.type === 'add') {
+      this.todos.push({ id: Date.now(), text: action.text, completed: false });
+    } else {
+      this.todos = this.todos.map((todo) =>
+        todo.id === action.id ? { ...todo, completed: !todo.completed } : todo
+      );
+    }
+    this.listeners.forEach((listener) => listener());
+  }
+
+  subscribe(listener: Listener) {
+    this.listeners.push(listener);
+  }
+}
+
+const dispatcher = new Dispatcher();
+const store = new TodoStore(dispatcher);
+store.subscribe(() => console.log('Updated todos'));
+dispatcher.dispatch({ type: 'add', text: 'Learn Flux' });`,
+      },
+    ],
+  },
+  {
+    id: 'event-bus',
+    name: 'Event Bus',
+    category: 'Modern',
+    description:
+      'A simple publish/subscribe mechanism for decoupled communication across an application.',
+    whenToUse: [
+      'Different parts of the app should react to events without tight coupling.',
+      'You want to reduce direct dependencies between modules.',
+    ],
+    benefits: [
+      'Lightweight messaging that is easy to drop into any project.',
+      'Supports many listeners reacting to the same event.',
+    ],
+    downsides: [
+      'Harder to trace flows because communication is indirect.',
+      'No built-in guarantees about delivery order or reliability.',
+    ],
+    examples: [
+      {
+        title: 'Basic Event Bus',
+        code: `type Handler<T> = (payload: T) => void;
+
+class EventBus {
+  private channels = new Map<string, Handler<unknown>[]>();
+
+  on<T>(event: string, handler: Handler<T>) {
+    const handlers = this.channels.get(event) ?? [];
+    handlers.push(handler as Handler<unknown>);
+    this.channels.set(event, handlers);
+  }
+
+  emit<T>(event: string, payload: T) {
+    const handlers = this.channels.get(event) ?? [];
+    handlers.forEach((handler) => handler(payload));
+  }
+}
+
+const bus = new EventBus();
+bus.on('login', (user: string) => console.log('User:', user));
+bus.emit('login', 'Ada');`,
+      },
+      {
+        title: 'Event Bus with Unsubscribe',
+        code: `class ReactiveBus {
+  private listeners = new Map<string, Set<Function>>();
+
+  on(event: string, listener: Function) {
+    const set = this.listeners.get(event) ?? new Set();
+    set.add(listener);
+    this.listeners.set(event, set);
+    return () => set.delete(listener);
+  }
+
+  emit(event: string, payload: unknown) {
+    this.listeners.get(event)?.forEach((listener) => listener(payload));
+  }
+}
+
+const reactive = new ReactiveBus();
+const off = reactive.on('change', (value) => console.log('Changed', value));
+reactive.emit('change', 1);
+off();`,
+      },
+    ],
+  },
+  {
+    id: 'cache-pattern',
+    name: 'Cache Pattern',
+    category: 'Modern',
+    description:
+      'Store expensive computation or fetch results so subsequent calls return quickly.',
+    whenToUse: [
+      'Fetching data or computing results is expensive.',
+      'Duplicate requests for the same data are common.',
+    ],
+    benefits: [
+      'Improves performance with minimal code.',
+      'Reduces load on databases and APIs.',
+    ],
+    downsides: [
+      'Cached data can become stale.',
+      'Requires invalidation strategy and storage management.',
+    ],
+    examples: [
+      {
+        title: 'Function Memoization',
+        code: `function memoize<T extends (...args: unknown[]) => unknown>(fn: T): T {
+  const cache = new Map<string, unknown>();
+  return ((...args: unknown[]) => {
+    const key = JSON.stringify(args);
+    if (!cache.has(key)) {
+      cache.set(key, fn(...args));
+    }
+    return cache.get(key);
+  }) as T;
+}
+
+const slowFib = (n: number): number => (n <= 1 ? n : slowFib(n - 1) + slowFib(n - 2));
+const fastFib = memoize(slowFib);
+fastFib(20);`,
+      },
+      {
+        title: 'Request Cache',
+        code: `class RequestCache {
+  private cache = new Map<string, Promise<string>>();
+
+  fetch(url: string) {
+    if (!this.cache.has(url)) {
+      this.cache.set(url, fetch(url).then((res) => res.text()));
+    }
+    return this.cache.get(url)!;
+  }
+}
+
+const cache = new RequestCache();
+cache.fetch('/api/profile');
+cache.fetch('/api/profile');`,
+      },
+    ],
+  },
+];
+
+const nav = document.getElementById('pattern-nav');
+const summaryEl = document.getElementById('pattern-summary');
+const benefitsEl = document.getElementById('pattern-benefits');
+const examplesEl = document.getElementById('pattern-examples');
+const titleEl = document.getElementById('pattern-title');
+const categoryEl = document.getElementById('pattern-category');
+
+const categories = patterns.reduce((map, pattern) => {
+  if (!map.has(pattern.category)) {
+    map.set(pattern.category, []);
+  }
+  map.get(pattern.category).push(pattern);
+  return map;
+}, new Map());
+
+const navItems = new Map();
+
+categories.forEach((items, category) => {
+  const group = document.createElement('div');
+  group.className = 'nav-group';
+
+  const title = document.createElement('h2');
+  title.className = 'nav-group__title';
+  title.textContent = `${category} Patterns`;
+  group.appendChild(title);
+
+  items.forEach((pattern) => {
+    const link = document.createElement('a');
+    link.href = `#${pattern.id}`;
+    link.className = 'nav-item';
+    link.textContent = pattern.name;
+    link.addEventListener('click', (event) => {
+      event.preventDefault();
+      setActivePattern(pattern.id);
+    });
+    group.appendChild(link);
+    navItems.set(pattern.id, link);
+  });
+
+  nav.appendChild(group);
+});
+
+function setActivePattern(id) {
+  const pattern = patterns.find((item) => item.id === id);
+  if (!pattern) return;
+
+  navItems.forEach((link, patternId) => {
+    link.classList.toggle('nav-item--active', patternId === id);
+  });
+
+  titleEl.textContent = pattern.name;
+  categoryEl.textContent = `${pattern.category} Pattern`;
+
+  summaryEl.innerHTML = `
+    <h3>Overview</h3>
+    <p>${pattern.description}</p>
+    <div class="pattern-meta">
+      <div>
+        <h4>When to use it</h4>
+        <ul>
+          ${pattern.whenToUse.map((item) => `<li>${item}</li>`).join('')}
+        </ul>
+      </div>
+    </div>
+  `;
+
+  benefitsEl.innerHTML = `
+    <h3>Benefits & Trade-offs</h3>
+    <div class="benefits-grid">
+      <div>
+        <h4>Benefits</h4>
+        <ul>
+          ${pattern.benefits.map((item) => `<li>${item}</li>`).join('')}
+        </ul>
+      </div>
+      <div>
+        <h4>Downsides</h4>
+        <ul>
+          ${pattern.downsides.map((item) => `<li>${item}</li>`).join('')}
+        </ul>
+      </div>
+    </div>
+  `;
+
+  renderExamples(pattern);
+
+  history.replaceState(null, '', `#${pattern.id}`);
+}
+
+function renderExamples(pattern) {
+  examplesEl.innerHTML = '';
+  const header = document.createElement('h3');
+  header.textContent = 'TypeScript Examples';
+  examplesEl.appendChild(header);
+
+  const tabs = document.createElement('div');
+  tabs.className = 'tabs';
+
+  const tabList = document.createElement('div');
+  tabList.className = 'tab-list';
+  tabList.setAttribute('role', 'tablist');
+
+  const panels = document.createElement('div');
+
+  pattern.examples.forEach((example, index) => {
+    const tab = document.createElement('button');
+    tab.className = 'tab-button';
+    tab.textContent = example.title;
+    tab.setAttribute('role', 'tab');
+    tab.setAttribute('aria-selected', index === 0 ? 'true' : 'false');
+    tab.addEventListener('click', () => activateTab(index));
+    tabList.appendChild(tab);
+
+    const panel = document.createElement('div');
+    panel.className = 'tab-panel';
+    if (index === 0) {
+      panel.classList.add('tab-panel--active');
+      tab.classList.add('tab-button--active');
+    }
+
+    const codeCard = document.createElement('div');
+    codeCard.className = 'code-card';
+
+    const codeHeader = document.createElement('div');
+    codeHeader.className = 'code-card__header';
+
+    const title = document.createElement('h4');
+    title.className = 'code-card__title';
+    title.textContent = example.title;
+
+    const copy = document.createElement('button');
+    copy.className = 'copy-button';
+    copy.textContent = 'Copy code';
+    copy.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(example.code);
+        copy.textContent = 'Copied!';
+        setTimeout(() => (copy.textContent = 'Copy code'), 1500);
+      } catch (error) {
+        copy.textContent = 'Press Ctrl+C';
+      }
+    });
+
+    codeHeader.appendChild(title);
+    codeHeader.appendChild(copy);
+
+    const pre = document.createElement('pre');
+    const code = document.createElement('code');
+    code.className = 'language-typescript';
+    code.textContent = example.code;
+    pre.appendChild(code);
+
+    codeCard.appendChild(codeHeader);
+    codeCard.appendChild(pre);
+
+    panel.appendChild(codeCard);
+    panels.appendChild(panel);
+  });
+
+  tabs.appendChild(tabList);
+  tabs.appendChild(panels);
+  examplesEl.appendChild(tabs);
+
+  highlightSnippets(panels);
+
+  function activateTab(index) {
+    const buttons = tabList.querySelectorAll('.tab-button');
+    const allPanels = panels.querySelectorAll('.tab-panel');
+
+    buttons.forEach((button, buttonIndex) => {
+      const isActive = buttonIndex === index;
+      button.classList.toggle('tab-button--active', isActive);
+      button.setAttribute('aria-selected', String(isActive));
+    });
+
+    allPanels.forEach((panel, panelIndex) => {
+      panel.classList.toggle('tab-panel--active', panelIndex === index);
+      if (panelIndex === index) {
+        highlightSnippets(panel);
+      }
+    });
+  }
+}
+
+const initialId = window.location.hash.replace('#', '') || patterns[0].id;
+setActivePattern(initialId);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,342 @@
+:root {
+  color-scheme: dark;
+  --bg: #101018;
+  --bg-elevated: #181828;
+  --text: #f4f4f8;
+  --muted: #9ea1b3;
+  --accent: #ff4d94;
+  --accent-soft: rgba(255, 77, 148, 0.18);
+  --border: #27293d;
+  --code-bg: #1b1b2b;
+  --code-border: #2d2d44;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+}
+
+.app {
+  display: flex;
+  width: 100%;
+}
+
+.sidebar {
+  width: 320px;
+  background: linear-gradient(180deg, #151523 0%, #101018 100%);
+  border-right: 1px solid var(--border);
+  padding: 2.5rem 1.5rem;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
+}
+
+.sidebar__header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.25rem;
+}
+
+.sidebar__logo {
+  display: block;
+  width: 72px;
+  height: 72px;
+  border-radius: 1.2rem;
+  box-shadow: 0 15px 30px rgba(255, 77, 148, 0.35);
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.15), transparent 60%),
+    rgba(255, 77, 148, 0.18);
+  padding: 0.75rem;
+}
+
+.sidebar__header h1 {
+  font-size: 1.6rem;
+  margin: 0;
+}
+
+.sidebar__tagline {
+  color: var(--muted);
+  margin: 0.35rem 0 2rem;
+}
+
+.sidebar__nav {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.nav-group {
+  border-radius: 0.8rem;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid transparent;
+  overflow: hidden;
+}
+
+.nav-group__title {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.nav-item {
+  display: block;
+  padding: 0.65rem 1rem;
+  text-decoration: none;
+  color: var(--text);
+  font-size: 0.98rem;
+  border-left: 3px solid transparent;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.nav-item:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.nav-item--active {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.content {
+  flex: 1;
+  padding: 3rem;
+  display: grid;
+  gap: 2rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.content__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.content__breadcrumbs {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin: 0;
+}
+
+.content__title {
+  font-size: 2.2rem;
+  margin: 0;
+}
+
+.card {
+  background: var(--bg-elevated);
+  border-radius: 1rem;
+  border: 1px solid var(--border);
+  padding: 1.75rem;
+  box-shadow: 0 30px 60px rgba(12, 12, 20, 0.45);
+}
+
+.card h3 {
+  margin-top: 0;
+  font-size: 1.4rem;
+}
+
+.card p {
+  line-height: 1.6;
+  color: var(--muted);
+}
+
+.card ul {
+  padding-left: 1.4rem;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.pattern-meta {
+  display: grid;
+  gap: 1rem;
+}
+
+.pattern-meta__usage {
+  margin: 0;
+}
+
+.benefits-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.benefits-grid h4 {
+  margin: 0 0 0.6rem;
+  font-size: 1.05rem;
+  color: var(--text);
+}
+
+.tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.tab-list {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.tab-button {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--muted);
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: border 0.2s ease, color 0.2s ease, background 0.2s ease;
+}
+
+.tab-button:hover {
+  color: var(--text);
+  border-color: var(--accent);
+}
+
+.tab-button--active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.tab-panel {
+  display: none;
+}
+
+.tab-panel--active {
+  display: block;
+}
+
+.code-card {
+  background: var(--code-bg);
+  border-radius: 0.8rem;
+  border: 1px solid var(--code-border);
+  padding: 1.2rem 1.2rem 1.4rem;
+  position: relative;
+}
+
+.code-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.8rem;
+}
+
+.code-card__title {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--text);
+}
+
+.copy-button {
+  border: none;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+  padding: 0.35rem 0.75rem;
+  border-radius: 0.6rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.copy-button:hover {
+  background: var(--accent);
+  color: #fff;
+}
+
+pre {
+  margin: 0;
+  background: var(--code-bg);
+  border: 1px solid var(--code-border);
+  border-radius: 0.9rem;
+  color: var(--text);
+  font-family: "Fira Code", "Source Code Pro", monospace;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  padding: 1.25rem;
+  overflow-x: auto;
+  overflow-y: visible;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02);
+}
+
+code {
+  white-space: pre;
+  display: block;
+}
+
+.token {
+  font-family: inherit;
+}
+
+.token-keyword {
+  color: #c678dd;
+}
+
+.token-type {
+  color: #e5c07b;
+}
+
+.token-string {
+  color: #98c379;
+}
+
+.token-number {
+  color: #d19a66;
+}
+
+.token-literal {
+  color: #56b6c2;
+}
+
+.token-comment {
+  color: #5c6370;
+  font-style: italic;
+}
+
+.token-decorator {
+  color: #61afef;
+}
+
+.token-class {
+  color: #e06c75;
+}
+
+@media (max-width: 1100px) {
+  .sidebar {
+    display: none;
+  }
+
+  .content {
+    padding: 2rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .content {
+    padding: 1.5rem;
+    gap: 1.5rem;
+  }
+
+  .card {
+    padding: 1.25rem;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the CDN-based highlighter with a lightweight in-app TypeScript tokenizer so syntax colors always render
- update example styling to match the Atom One Dark palette and keep snippets fully visible without scrollbars

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e2175f8fa08324910130a25127a0d7